### PR TITLE
changes to fix invalid path issue

### DIFF
--- a/Node/exercise2-TicketSubmissionDialog/app.js
+++ b/Node/exercise2-TicketSubmissionDialog/app.js
@@ -82,8 +82,8 @@ var bot = new builder.UniversalBot(connector, [
 ]);
 
 const createCard = (ticketId, data) => {
-    var cardTxt = fs.readFileSync(path.join(__dirname, "/cards/ticket.json"), 'UTF-8');
-
+    var cardTxt = fs.readFileSync('./cards/ticket.json', 'UTF-8');
+    
     cardTxt = cardTxt.replace(/{ticketId}/g, ticketId)
                     .replace(/{severity}/g, data.severity)
                     .replace(/{category}/g, data.category)

--- a/Node/exercise2-TicketSubmissionDialog/app.js
+++ b/Node/exercise2-TicketSubmissionDialog/app.js
@@ -1,5 +1,6 @@
 /* jshint esversion: 6 */
 require('dotenv').config();
+path = require('path');
 const restify = require('restify');
 const fs = require('fs');
 const builder = require('botbuilder');
@@ -81,7 +82,7 @@ var bot = new builder.UniversalBot(connector, [
 ]);
 
 const createCard = (ticketId, data) => {
-    var cardTxt = fs.readFileSync('C:/projects/help-desk-bot-lab/Node/exercise2-TicketSubmissionDialog/cards/ticket.json', 'UTF-8');
+    var cardTxt = fs.readFileSync(path.join(__dirname, "/cards/ticket.json"), 'UTF-8');
 
     cardTxt = cardTxt.replace(/{ticketId}/g, ticketId)
                     .replace(/{severity}/g, data.severity)

--- a/Node/exercise2-TicketSubmissionDialog/app.js
+++ b/Node/exercise2-TicketSubmissionDialog/app.js
@@ -1,6 +1,6 @@
 /* jshint esversion: 6 */
 require('dotenv').config();
-path = require('path');
+const path = require('path');
 const restify = require('restify');
 const fs = require('fs');
 const builder = require('botbuilder');

--- a/Node/exercise2-TicketSubmissionDialog/package.json
+++ b/Node/exercise2-TicketSubmissionDialog/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "botbuilder": "^3.8.4",
     "dotenv": "^4.0.0",
+    "path": "^0.12.7",
     "restify": "^4.3.0"
   },
   "devDependencies": {

--- a/Node/exercise2-TicketSubmissionDialog/package.json
+++ b/Node/exercise2-TicketSubmissionDialog/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "botbuilder": "^3.8.4",
     "dotenv": "^4.0.0",
-    "path": "^0.12.7",
     "restify": "^4.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Nodejs Exercise 2 currently fails at the last step before card is rendered 

* Reason: because path mentioned in readfilesync is relatie to "c:/", i.e.  "C:/projects/help-desk-bot-lab/Node/exercise2-TicketSubmissionDialog/cards/ticket.json".
